### PR TITLE
type option for stages within a flow as it can be a list of GenStage.…

### DIFF
--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -405,7 +405,7 @@ defmodule Flow do
                    options: keyword(), window: Flow.Window.t}
 
   @typep producers :: nil |
-                      {:stages, GenStage.stage} |
+                      {:stages, GenStage.stage | [GenStage.stage]} |
                       {:enumerables, Enumerable.t} |
                       {:join, t, t, fun(), fun(), fun()} |
                       {:flows, [t]}


### PR DESCRIPTION
…stage(s)

When dealing w/ `from_stages`, the `:stages:` key in type `producers` can be a list of GenStage.stage's/pids.

E.g. 

```elixir
%Flow{operations: [{:reduce, #Function<2.6601765/0 in Drazil.Pipeline.Processor.flow/2>, #Function<3.6601765/2 in Drazil.Pipeline.Processor.flow/2>}], options: [stages: 8, key: #Function<1.6601765/1 in Drazil.Pipeline.Processor.flow/2>], producers: {:flows, [%Flow{operations: [{:mapper, :filter, [#Function<0.6601765/1 in Drazil.Pipeline.Processor.flow/2>]}], options: [stages: 8], producers: {:stages, [#PID<0.326.0>]}, window: %Flow.Window.Global{periodically: [], trigger: nil}}]}, window: %Flow.Window.Periodic{duration: 1000, periodically: [], trigger: nil}}
```