### PR TITLE
Added gen_stage to the applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Flow.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :gen_stage]]
   end
 
   defp deps do


### PR DESCRIPTION
This is giving an error on Elixir 1.3 releases, since the `gen_stage` application is not packaged as it's not listed.