### PR TITLE
Keep collected and make sure periodic trigger fn returns timer.

### DIFF
--- a/lib/flow/materialize.ex
+++ b/lib/flow/materialize.ex
@@ -389,10 +389,10 @@ defmodule Flow.Materialize do
         maybe_punctuate(ref, pos, punctuation_fun, pun_acc, red_acc,
                         red_fun, index, name, trigger, collected ++ trigger_events ++ red_events)
       {:cont, [], pun_acc} ->
-        {[], {pun_acc, red_acc}}
+        {collected, {pun_acc, red_acc}}
       {:cont, emitted_events, pun_acc} ->
         {red_events, red_acc} = red_fun.(ref, emitted_events, red_acc, index)
-        {red_events, {pun_acc, red_acc}}
+        {collected ++ red_events, {pun_acc, red_acc}}
       {:cont, pun_acc} ->
         {red_events, red_acc} = red_fun.(ref, events, red_acc, index)
         {collected ++ red_events, {pun_acc, red_acc}}

--- a/lib/flow/window/periodic.ex
+++ b/lib/flow/window/periodic.ex
@@ -31,7 +31,7 @@ defmodule Flow.Window.Periodic do
 
     trigger =
       fn
-        {window, timer, acc}, index, op, ^ref ->
+        {window, _timer, acc}, index, op, ^ref ->
           {emit, _} = reducer_trigger.(acc, index, op, {:periodic, window, :done})
           timer = send_after(ref, duration)
           {emit, {window + 1, timer, reducer_acc.()}}

--- a/lib/flow/window/periodic.ex
+++ b/lib/flow/window/periodic.ex
@@ -38,7 +38,7 @@ defmodule Flow.Window.Periodic do
         {window, timer, acc}, index, op, name ->
           if name == :done, do: cancel_after(ref, timer)
           {emit, acc} = reducer_trigger.(acc, index, op, {:periodic, window, name})
-          {emit, {window, acc}}
+          {emit, {window, timer, acc}}
       end
 
     {acc, fun, trigger}


### PR DESCRIPTION
@josevalim found a couple minor bugs:  One wrt the `cont` w/ emitted events tuple. It's now correct when returning values upon evaluation via enumeration. The other is making sure the timer is correctly included in the periodic window trigger fun. 