### PR TITLE
Initial Implemetation of Sliding Event Window

### DIFF
--- a/lib/flow/window.ex
+++ b/lib/flow/window.ex
@@ -352,6 +352,21 @@ defmodule Flow.Window do
   end
 
   @doc """
+  Returns a sliding event window of every `count` elements where each new window
+  starts `overlap` elements into the last window.
+
+  `count` and `overlap` must be a positive integer.
+
+  Sliding window triggers have the shape of `{:sliding, window, trigger_name}`,
+  where `window` is an incrementing integer identifying the window.
+  """
+  @spec sliding_event(pos_integer, pos_integer) :: t
+  def sliding_event(count, overlap)
+      when is_integer(count) and count > 0 and is_integer(overlap) and count > overlap do
+    %Flow.Window.SlidingEvent{count: count, overlap: overlap}
+  end
+
+  @doc """
   Returns a periodic-based window on every `count` `unit`.
 
   `count` is a positive integer and `unit` is one of `:millisecond`,

--- a/lib/flow/window/sliding_event.ex
+++ b/lib/flow/window/sliding_event.ex
@@ -1,0 +1,83 @@
+defmodule Flow.Window.SlidingEvent do
+  @moduledoc false
+
+  @enforce_keys [:count, :overlap]
+  defstruct [:count, :overlap, :trigger, periodically: []]
+
+  def departition(flow) do
+    flow
+  end
+
+  def materialize(%{count: max, overlap: max_overlap}, reducer_acc, reducer_fun, reducer_trigger, _options) do
+    acc =
+      fn -> {0, max, [], reducer_acc.()} end
+
+    fun =
+      fn ref, events, {window, count, overlap_events, acc}, index ->
+        dispatch(events, overlap_events, window, count, [], acc,
+                 ref, index, max, max_overlap, reducer_acc, reducer_fun, reducer_trigger)
+      end
+
+    trigger =
+      fn {window, count, _overlap_events, acc}, index, op, name ->
+        {emit, acc} = reducer_trigger.(acc, index, op, {:sliding, window, name})
+        {emit, {window, count, acc}}
+      end
+
+    {acc, fun, trigger}
+  end
+
+  defp dispatch([], overlap_events, window, count, emit, acc, _ref, _index, _max, _overlap, _reducer_acc, _reducer_fun, _reducer_trigger) do
+    {emit, {window, count, overlap_events, acc}}
+  end
+  defp dispatch(events, overlap_events, window, count, emit, acc, ref, index, max, overlap, reducer_acc, reducer_fun, reducer_trigger) do
+    {count, events, rest} =
+      collect(events, count, [])
+
+    overlap_events = if count < overlap do
+      overlap_events ++ collect_overlap(events, count, overlap)
+    else
+      overlap_events
+    end
+
+    {overlap_events, rest} = if length(overlap_events) == overlap do
+      {[], overlap_events ++ rest}
+    else
+      {overlap_events, rest}
+    end
+
+    {reducer_emit, acc} =
+      maybe_dispatch(events, acc, ref, index, window, reducer_fun)
+    {trigger_emit, acc, window, count} =
+      maybe_trigger(window, count, acc, index, max, reducer_acc, reducer_trigger)
+    dispatch(rest, overlap_events, window, count, emit ++ reducer_emit ++ trigger_emit, acc,
+             ref, index, max, overlap, reducer_acc, reducer_fun, reducer_trigger)
+  end
+
+  defp maybe_trigger(window, 0, acc, index, max, reducer_acc, reducer_trigger) do
+    {trigger_emit, _} = reducer_trigger.(acc, index, :keep, {:sliding, window, :done})
+    {trigger_emit, reducer_acc.(), window + 1, max}
+  end
+  defp maybe_trigger(window, count, acc, _index, _max, _reducer_acc, _reducer_trigger) do
+    {[], acc, window, count}
+  end
+
+  defp maybe_dispatch([], acc, _ref, _index, _window, _reducer_fun) do
+    {[], acc}
+  end
+  defp maybe_dispatch(events, acc, ref, index, window, reducer_fun) do
+    if is_function(reducer_fun, 4) do
+      reducer_fun.(ref, events, acc, index)
+    else
+      reducer_fun.(ref, events, acc, index, {:sliding, window, :placeholder})
+    end
+  end
+
+  defp collect([], count, acc), do: {count, :lists.reverse(acc), []}
+  defp collect(events, 0, acc), do: {0, :lists.reverse(acc), events}
+  defp collect([event | events], count, acc), do: collect(events, count - 1, [event | acc])
+
+  defp collect_overlap(events, count, overlap) do
+    Enum.reverse(events) |> Enum.take(overlap - count) |> Enum.reverse()
+  end
+end

--- a/test/flow/window/sliding_event_test.exs
+++ b/test/flow/window/sliding_event_test.exs
@@ -1,0 +1,18 @@
+defmodule Flow.Window.SlidingEventTest do
+  use ExUnit.Case, async: true
+
+  defp single_window do
+    Flow.Window.sliding_event(2, 1)
+  end
+
+  describe "single window" do
+    test "with multiple mappers and reducers" do
+      assert Flow.from_enumerable(1..100, stages: 4, max_demand: 5)
+             |> Flow.map(&(&1))
+             |> Flow.partition(window: single_window(), stages: 1)
+             |> Flow.reduce(fn -> 0 end, & &1 + &2)
+             |> Flow.emit(:state)
+             |> Enum.sum() == 10099
+    end
+  end
+end


### PR DESCRIPTION
This is my first proposal on the sliding event window implementation proposed in #26. I used the code of `window/count.ex` and amended it for overlapping events. Deduplication of code can still happen later.

The implementation seems to work for single stages but not quite sure about multi stages. I'm not even sure a sliding window makes sense in a multi stage scenario (in which stage should the overlapping events go).

I just wanted to make sure that this is going in the right direction. Let me know what you think.