### PR TITLE
Favor guards instead of pattern match for list args

### DIFF
--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -500,7 +500,7 @@ defmodule Flow do
   @spec from_enumerables([Enumerable.t], keyword) :: t
   def from_enumerables(enumerables, options \\ [])
 
-  def from_enumerables([_ | _] = enumerables, options) do
+  def from_enumerables(enumerables, options) when is_list(enumerables) do
     options = stages(options)
     {window, options} = Keyword.pop(options, :window, Flow.Window.global)
     %Flow{producers: {:enumerables, enumerables}, options: options, window: window}
@@ -568,7 +568,7 @@ defmodule Flow do
   @spec from_stages([GenStage.stage], keyword) :: t
   def from_stages(stages, options \\ [])
 
-  def from_stages([_ | _] = stages, options) do
+  def from_stages(stages, options) when is_list(stages) do
     options = stages(options)
     {window, options} = Keyword.pop(options, :window, Flow.Window.global)
     %Flow{producers: {:stages, stages}, options: options, window: window}


### PR DESCRIPTION
Was reading through the source and encountered these two function heads that I believe would be slightly more readable as guards instead of pattern matches. The assertions are still the same as far as I'm aware. Is there a performance reason why one is favored over the other?