### PR TITLE
Fix erroneous doc example

### DIFF
--- a/lib/flow/window.ex
+++ b/lib/flow/window.ex
@@ -52,7 +52,7 @@ defmodule Flow.Window do
   is equivalent to:
 
       Flow.from_stage(some_producer)
-      |> Flow.partition(Flow.Window.global())
+      |> Flow.partition(window: Flow.Window.global())
       |> Flow.reduce(fn -> 0 end, & &1 + 2)
 
   Even though the global window does not split the data in any way, it


### PR DESCRIPTION
When running through some of the code examples, I couldn't get the edited snippet to work until I treated it as a keyword list. Seems to conform with later examples, though.