### PR TITLE
raise error when producer crashes

### DIFF
--- a/lib/flow/map_reducer.ex
+++ b/lib/flow/map_reducer.ex
@@ -3,6 +3,7 @@ defmodule Flow.MapReducer do
   use GenStage
 
   def init({type, opts, index, trigger, acc, reducer}) do
+    Process.flag(:trap_exit, true)
     {type, {%{}, build_status(type, trigger), index, acc.(), reducer}, opts}
   end
 

--- a/test/flow_test.exs
+++ b/test/flow_test.exs
@@ -55,6 +55,16 @@ defmodule FlowTest do
         Flow.from_enumerable([1, 2, 3], window: Flow.Window.fixed(1, :second, & &1)) |> Enum.to_list
       )
     end
+
+    @tag :capture_log
+    test "on error in producer" do
+      assert catch_exit(
+        :start
+        |> Stream.iterate(fn _ -> raise "oops" end)
+        |> Flow.from_enumerable(stages: 1, max_demand: 1)
+        |> Flow.run
+      )
+    end
   end
 
   describe "run/1" do


### PR DESCRIPTION
addresses #35 
@josevalim, per your suggestion I started looking into DOWN messages in map_reducer and trapped EXIT for debug purposes when suddenly tests passed. Honestly, as with our previous "solutions" I don't completely understand it. Looking at `terminate` call, it receives correct runtime error and I assume it's being correctly raised in the tree. 