### PR TITLE
Reference deparition/5 properly from take_sort/3 documentation

### DIFF
--- a/lib/flow.ex
+++ b/lib/flow.ex
@@ -1193,7 +1193,7 @@ defmodule Flow do
   final result is a flow with a single partition that will emit a list
   with the top `n` events. The sorting is given by the `sort_fun`.
 
-  `take_sort/3` is built on top of departition, which means it will
+  `take_sort/3` is built on top of `departition/5`, which means it will
   also take and sort entries across windows.
 
   ## Examples


### PR DESCRIPTION
Just a small improvement to the documentation, so that the functions are properly linked in the rendered docs.

I also think that another piece of documentation could be improved, but I'm not sure if my reasoning is correct. In the docs for `take_sort/3`the user is told that "it will also take and sort entries across windows". However, docs for `departition/5` state that "A new accumulator is created per window...", which would mean that `take_sort/3` emits top `n` events per window. If I am correct here, I think it'd be nice to mention that in the docs, too.