### PR TITLE
Don't fuse mappers into enumerables

### DIFF
--- a/test/flow_test.exs
+++ b/test/flow_test.exs
@@ -372,13 +372,6 @@ defmodule FlowTest do
       assert @flow |> Enum.sort() == [1, 2, 3, 4, 5, 6]
     end
 
-    test "fuses when there are more enumerables than stages" do
-      assert Flow.from_enumerables([[1, 2, 3], [4, 5, 6], 7..10], stages: 2)
-             |> Flow.map(fn _ -> self() end)
-             |> Enum.uniq()
-             |> Enum.count() == 3
-    end
-
     @tag :capture_log
     test "raises locally" do
       assert catch_exit(@flow |> Flow.map(fn _ -> raise "oops" end) |> Enum.to_list())
@@ -595,14 +588,6 @@ defmodule FlowTest do
              |> Flow.on_trigger(&{[&1], &1})
              |> Enum.map(&Enum.sort/1)
              |> Enum.sort() == [[1, 5, 7, 9], [2, 6, 8], [3, 4], [10]]
-    end
-
-    test "fuses when there are more enumerables than stages" do
-      assert Flow.from_enumerables([[1, 2, 3], [4, 5, 6], 7..10], stages: 2)
-             |> Flow.map(fn _ -> self() end)
-             |> Flow.partition(stages: 4)
-             |> Enum.uniq()
-             |> length() == 3
     end
 
     @tag :capture_log


### PR DESCRIPTION
This prevents unexpected level of parallelism between mapper operations.

Closes #62.