### PR TITLE
Another round of smaller changes

### DIFF
--- a/lib/flow/materialize.ex
+++ b/lib/flow/materialize.ex
@@ -170,11 +170,9 @@ defmodule Flow.Materialize do
 
     producers_consumers = producers_consumers.(start_link)
 
-    for {pid, _} <- intermediary do
-      for {producer_consumer, subscribe_opts} <- producers_consumers do
-        subscribe_opts = [to: pid, cancel: :transient] ++ subscribe_opts
-        GenStage.sync_subscribe(producer_consumer, subscribe_opts, timeout)
-      end
+    for {pid, _} <- intermediary, {producer_consumer, subscribe_opts} <- producers_consumers do
+      subscribe_opts = [to: pid, cancel: :transient] ++ subscribe_opts
+      GenStage.sync_subscribe(producer_consumer, subscribe_opts, timeout)
     end
 
     producers_consumers =

--- a/lib/flow/materialize.ex
+++ b/lib/flow/materialize.ex
@@ -605,7 +605,7 @@ defmodule Flow.Materialize do
   end
 
   defp build_emit_and_reducer(mappers, fun) do
-    reducer = :lists.foldl(&mapper/2, fun, mappers)
+    reducer = reducer_from_mappers(mappers, fun)
 
     emit_and_reducer = fn event, {events, acc} ->
       case reducer.(event, acc) do
@@ -621,7 +621,7 @@ defmodule Flow.Materialize do
   end
 
   defp build_reducer(mappers, fun) do
-    reducer = :lists.foldl(&mapper/2, fun, mappers)
+    reducer = reducer_from_mappers(mappers, fun)
 
     fn _ref, events, acc, _index ->
       {[], :lists.foldl(reducer, acc, events)}
@@ -637,7 +637,7 @@ defmodule Flow.Materialize do
         fun
 
       {mappers, [{:on_trigger, fun}]} ->
-        reducer = :lists.foldl(&mapper/2, &[&1 | &2], mappers)
+        reducer = reducer_from_mappers(mappers)
 
         fn acc, index, trigger ->
           acc |> Enum.reduce([], reducer) |> Enum.reverse() |> fun.(index, trigger)
@@ -664,13 +664,13 @@ defmodule Flow.Materialize do
         end
 
       {mappers, []} ->
-        reducer = :lists.foldl(&mapper/2, &[&1 | &2], mappers)
+        reducer = reducer_from_mappers(mappers)
         fn acc, _, _ -> {acc |> Enum.reduce([], reducer) |> Enum.reverse(), acc} end
     end
   end
 
   defp build_uniq_reducer(mappers, reducer, uniq_by) do
-    uniq_by = :lists.foldl(&mapper/2, uniq_by_reducer(uniq_by), mappers)
+    uniq_by = reducer_from_mappers(mappers, uniq_by_reducer(uniq_by))
 
     fn ref, events, {set, acc}, index ->
       {set, events} = :lists.foldl(uniq_by, {set, []}, events)
@@ -700,11 +700,15 @@ defmodule Flow.Materialize do
   ## Mappers
 
   defp mapper_ops(ops) do
-    reducer = :lists.foldl(&mapper/2, &[&1 | &2], ops)
+    reducer = reducer_from_mappers(ops)
 
     {fn -> [] end,
      fn _ref, events, [], _index -> {:lists.reverse(:lists.foldl(reducer, [], events)), []} end,
      fn _acc, _index, _trigger -> {[], []} end}
+  end
+
+  defp reducer_from_mappers(mappers, reducer \\ &[&1 | &2]) do
+    :lists.foldl(&mapper/2, reducer, mappers)
   end
 
   defp mapper({:mapper, :each, [each]}, fun) do

--- a/lib/flow/window.ex
+++ b/lib/flow/window.ex
@@ -260,9 +260,9 @@ defmodule Flow.Window do
   @type type :: :global | :fixed | :session | :periodic | :count | any()
 
   @typedoc """
-  A function that retrieves the field to window by.
+  A function that returns the event time to window by.
 
-  It must be an integer representing the time in milliseconds.
+  It must return an integer representing the time in milliseconds.
   Flow does not care if the integer is using the UNIX epoch,
   Gregorian epoch or any other as long as it is consistent.
   """
@@ -271,8 +271,7 @@ defmodule Flow.Window do
   @typedoc """
   The window identifier.
 
-  It is `:global` for `:global` windows or
-  an integer for fixed windows.
+  It is `:global` for `:global` windows or an integer for fixed windows.
   """
   @type id :: :global | non_neg_integer()
 
@@ -307,10 +306,10 @@ defmodule Flow.Window do
   end
 
   @doc """
-  Returns a periodic-based window on every `count` `unit`.
+  Returns a period-based window of every `count` `unit`.
 
   `count` is a positive integer and `unit` is one of `:millisecond`,
-  `:second`, `:minute`, `:hour`. Remember periodic triggers are established
+  `:second`, `:minute`, or `:hour`. Remember periodic triggers are established
   per partition and are message-based, which means partitions will emit the
   triggers at different times and possibly with delays based on the partition
   message queue size.
@@ -330,7 +329,7 @@ defmodule Flow.Window do
   event time is calculated by the given function `by`.
 
   `count` is a positive integer and `unit` is one of `:millisecond`,
-  `:second`, `:minute`, `:hour`.
+  `:second`, `:minute`, or `:hour`.
 
   Fixed window triggers have the shape of `{:fixed, window, trigger_name}`,
   where `window` is an integer that represents the beginning timestamp
@@ -364,7 +363,7 @@ defmodule Flow.Window do
   effectively emitting the `:done` trigger.
 
   `count` is a positive number. The `unit` may be a time unit
-  (`:second`, `:millisecond`, `:second`, `:minute` and `:hour`).
+  (`:millisecond`, `:second`, `:minute`, or `:hour`).
   """
   @spec allowed_lateness(t, pos_integer, System.time_unit()) :: t
   def allowed_lateness(window, count, unit)
@@ -391,16 +390,16 @@ defmodule Flow.Window do
   The trigger function must return one of the three values:
 
     * `{:cont, acc}` - the reduce operation should continue as usual.
-       `acc` is the trigger state.
+      `acc` is the trigger state.
 
     * `{:cont, events, acc}` - the reduce operation should continue, but
-       only with the events you want to emit as part of the next state.
-       `acc` is the trigger state.
+      only with the events you want to emit as part of the next state.
+      `acc` is the trigger state.
 
-    * `{:trigger, name, pre, pos, acc}` - where `name` is the
-      trigger `name`, `pre` are the events to be consumed before the trigger,
-      `pos` controls events to be processed after the trigger with the `acc`
-      as the new trigger accumulator.
+    * `{:trigger, name, pre, pos, acc}` - where `name` is the trigger `name`,
+      `pre` are the events to be consumed before the trigger, `pos` controls
+      events to be processed after the trigger with the `acc` as the new trigger
+      accumulator.
 
   We recommend looking at the implementation of `trigger_every/3` as
   an example of a custom trigger.
@@ -464,7 +463,7 @@ defmodule Flow.Window do
   periodic trigger.
 
   `count` is a positive integer and `unit` is one of `:millisecond`,
-  `:second`, `:minute`, `:hour`. Remember periodic triggers are established
+  `:second`, `:minute`, or `:hour`. Remember periodic triggers are established
   per partition and are message-based, which means partitions will emit the
   triggers at different times and possibly with delays based on the partition
   message queue size.

--- a/lib/flow/window.ex
+++ b/lib/flow/window.ex
@@ -254,7 +254,7 @@ defmodule Flow.Window do
   between count windows and global windows with count triggers.
   """
 
-  @type t :: %{required(:trigger) => {fun(), fun()} | nil, required(:periodically) => []}
+  @type t :: %{required(:trigger) => {fun(), fun()} | nil, required(:periodically) => [trigger]}
 
   @typedoc "The supported window types."
   @type type :: :global | :fixed | :session | :periodic | :count | any()
@@ -274,6 +274,11 @@ defmodule Flow.Window do
   It is `:global` for `:global` windows or an integer for fixed windows.
   """
   @type id :: :global | non_neg_integer()
+
+  @typedoc """
+  The supported time units for fixed and periodic windows.
+  """
+  @type time_unit :: :millisecond | :second | :minute | :hour
 
   @typedoc "The name of the trigger."
   @type trigger :: term
@@ -319,7 +324,7 @@ defmodule Flow.Window do
 
   See the section on "Periodic windows" in the module documentation for examples.
   """
-  @spec periodic(pos_integer, System.time_unit()) :: t
+  @spec periodic(pos_integer, time_unit) :: t
   def periodic(count, unit) when is_integer(count) and count > 0 do
     %Flow.Window.Periodic{duration: to_ms(count, unit)}
   end
@@ -342,7 +347,7 @@ defmodule Flow.Window do
 
   See the section on "Fixed windows" in the module documentation for examples.
   """
-  @spec fixed(pos_integer, System.time_unit(), (t -> pos_integer)) :: t
+  @spec fixed(pos_integer, time_unit, (t -> pos_integer)) :: t
   def fixed(count, unit, by) when is_integer(count) and count > 0 and is_function(by, 1) do
     %Flow.Window.Fixed{duration: to_ms(count, unit), by: by}
   end
@@ -365,7 +370,7 @@ defmodule Flow.Window do
   `count` is a positive number. The `unit` may be a time unit
   (`:millisecond`, `:second`, `:minute`, or `:hour`).
   """
-  @spec allowed_lateness(t, pos_integer, System.time_unit()) :: t
+  @spec allowed_lateness(t, pos_integer, time_unit) :: t
   def allowed_lateness(window, count, unit)
 
   def allowed_lateness(%{lateness: _} = window, count, unit) do
@@ -480,7 +485,7 @@ defmodule Flow.Window do
   Similar to periodic triggers, message-based triggers will also be
   invoked to all windows that have changed since the last trigger.
   """
-  @spec trigger_periodically(t, pos_integer, System.time_unit()) :: t
+  @spec trigger_periodically(t, pos_integer, time_unit) :: t
   def trigger_periodically(%{periodically: periodically} = window, count, unit)
       when is_integer(count) and count > 0 do
     trigger = {to_ms(count, unit), {:periodically, count, unit}}

--- a/test/flow_test.exs
+++ b/test/flow_test.exs
@@ -430,7 +430,7 @@ defmodule FlowTest do
       assert Enum.sort(flow) == [6, 10, 14]
     end
 
-    test "allows custom windowding" do
+    test "allows custom windowing" do
       window =
         Flow.Window.fixed(1, :second, fn
           x when x <= 50 -> 0
@@ -1051,7 +1051,7 @@ defmodule FlowTest do
              |> Enum.sort() == [[1, 2, 4, 5], [3, 6]]
     end
 
-    test "allows custom windowding" do
+    test "allows custom windowing" do
       window =
         Flow.Window.fixed(1, :second, fn
           x when x <= 50 -> 0
@@ -1208,7 +1208,7 @@ defmodule FlowTest do
              |> Enum.sort() == [0, 0, 0, 10100]
     end
 
-    test "allows custom windowding" do
+    test "allows custom windowing" do
       window =
         Flow.Window.fixed(1, :second, fn
           x when x <= 100 -> 0
@@ -1244,7 +1244,7 @@ defmodule FlowTest do
              |> Enum.sum() == 10100
     end
 
-    test "allows custom windowding" do
+    test "allows custom windowing" do
       window =
         Flow.Window.fixed(1, :second, fn
           x when x <= 100 -> 0


### PR DESCRIPTION
@josevalim let me know if you're not convinced by any of these. Personally, I'm not sure about `reducer_from_mappers` in the first commit. I just couldn't resist removing the duplication, but now I don't now if it helps or just unnecessarily hides the `:lists.foldl/3` call.