### PR TITLE
Attempt to fix random failures on CI

### DIFF
--- a/test/flow_test.exs
+++ b/test/flow_test.exs
@@ -432,7 +432,11 @@ defmodule FlowTest do
 
       windows =
         Flow.from_enumerable(1..100, window: window, stages: 4, max_demand: 5)
-        |> Flow.reduce(fn -> 0 end, &(&1 + &2))
+        |> Flow.reduce(fn -> 0 end, fn n, acc ->
+          # slowing down the flow a bit in order to make it more deterministic
+          Process.sleep(1)
+          n + acc
+        end)
         |> Flow.on_trigger(&{[&1], &1})
         |> Enum.to_list()
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
-assert_timeout = String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT") || "500")
+assert_timeout = String.to_integer(System.get_env("ELIXIR_ASSERT_TIMEOUT") || "1000")
 
 ExUnit.start(assert_receive_timeout: assert_timeout)


### PR DESCRIPTION
Closes #64.

I tested the flow with the race condition with larger inputs, but that
didn't seem to help much. I was able to get outputs with less than
8 windows after less than 100 000 runs (that was for `1..10_000`, 4000 for `1..1000`).

Adding a tiny delay in the reduce step seems to be a better approach and
only slows down the test to about `56ms`.